### PR TITLE
Add Shuffleboard Voltage Monitoring

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -37,6 +37,7 @@ public class RobotContainer {
    private final Shifty shifty = new Shifty();
    private final Collector collector = new Collector();
    private final Launcher launcher = new Launcher();
+   private final Voltage voltage = new Voltage();
    
    //controllers
    private final Joystick leftDrive = new Joystick(JoystickConstants.Ports.DRIVER_LEFT);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -15,29 +15,13 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
-
-
-/* TODO: This stuff:
- * manually check launcher inverts
- * check encoder output (manually)
- * check collector deploy switch output
- * check launcher limit switch output
- * check collector deploy "invert"
- * check if launcher stop works without collector plugged in
- * check that collector deploy before launching
- * check if collector and launcher work in tandem
- * tune launcher powers
-*/
-
-
-
 public class RobotContainer {
    //subsystems
    private final Drivetrain drivetrain = new Drivetrain();
    private final Shifty shifty = new Shifty();
    private final Collector collector = new Collector();
    private final Launcher launcher = new Launcher();
-   private final Voltage voltage = new Voltage();
+   private final Voltage voltage = new Voltage(); // read only
    
    //controllers
    private final Joystick leftDrive = new Joystick(JoystickConstants.Ports.DRIVER_LEFT);

--- a/src/main/java/frc/robot/constants/RobotMap.java
+++ b/src/main/java/frc/robot/constants/RobotMap.java
@@ -1,6 +1,10 @@
 package frc.robot.constants;
 
 public class RobotMap {
+    //Analog
+    //Voltage
+    public static final int VOLTAGE = 0;
+
     //PWM
     //DRIVETRAIN
     public static final int LEFT1 = 0;

--- a/src/main/java/frc/robot/subsystems/Collector.java
+++ b/src/main/java/frc/robot/subsystems/Collector.java
@@ -15,7 +15,6 @@ import edu.wpi.first.wpilibj.DoubleSolenoid.Value;
 
 public class Collector extends SubsystemBase {
     private Talon collector = new Talon(RobotMap.COLLECTOR);
-    private DigitalInput deploySwitch = new DigitalInput(RobotMap.COLLECTOR_SWITCH);
     private DoubleSolenoid deploy = new DoubleSolenoid(RobotMap.PCM, PneumaticsModuleType.CTREPCM, RobotMap.DEPLOY_1, RobotMap.DEPLOY_2);
 
     private ShuffleboardTab demoTab = Shuffleboard.getTab("demo");

--- a/src/main/java/frc/robot/subsystems/Voltage.java
+++ b/src/main/java/frc/robot/subsystems/Voltage.java
@@ -1,5 +1,10 @@
 package frc.robot.subsystems;
 
+import edu.wpi.first.wpilibj.AnalogInput;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Voltage extends SubsystemBase {

--- a/src/main/java/frc/robot/subsystems/Voltage.java
+++ b/src/main/java/frc/robot/subsystems/Voltage.java
@@ -1,0 +1,23 @@
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class Voltage extends SubsystemBase {
+    private ShuffleboardTab demoTab = Shuffleboard.getTab("demo");
+
+    private NetworkTableEntry voltageEntry = demoTab.add("Voltage", 0).getEntry();
+
+    private AnalogInput voltageSensor = new AnalogInput(0);
+    public Voltage() {
+        CommandScheduler.getInstance().registerSubsystem(this);
+    }
+
+    @Override
+    public void periodic() {
+        voltageEntry.setDouble(getVoltage());
+    }
+
+    public double getVoltage(){
+        return voltageSensor.getVoltage() * 3;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/Voltage.java
+++ b/src/main/java/frc/robot/subsystems/Voltage.java
@@ -6,13 +6,14 @@ import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.constants.RobotMap;
 
 public class Voltage extends SubsystemBase {
     private ShuffleboardTab demoTab = Shuffleboard.getTab("demo");
 
     private NetworkTableEntry voltageEntry = demoTab.add("Voltage", 0).getEntry();
 
-    private AnalogInput voltageSensor = new AnalogInput(0);
+    private AnalogInput voltageSensor = new AnalogInput(RobotMap.VOLTAGE);
     public Voltage() {
         CommandScheduler.getInstance().registerSubsystem(this);
     }


### PR DESCRIPTION
- Added:
    - a voltage divider to make the old pdp work
    - Voltage.java subsystem that dumps voltage readings on shuffleboard
- TODO:
    - Someone (not Michael) please review to sanity check the magic number 3 on line 27 of Voltage.java:
        - https://en.wikipedia.org/wiki/Voltage_divider
